### PR TITLE
Add support for arm64 architecture

### DIFF
--- a/download/downloadSpec.go
+++ b/download/downloadSpec.go
@@ -118,6 +118,8 @@ func detectArch() (string, error) {
 	switch goArch {
 	case "amd64":
 		return "x86_64", nil
+	case "arm64":
+		return "arm64", nil
 	default:
 		return "", &UnsupportedSystemError{msg: "architecture " + goArch + " not supported"}
 	}


### PR DESCRIPTION
### What

Added support to download mongo binary for arm64 processors

### How to review

Try to use the library on any arm64 processor

